### PR TITLE
Obey tab-stops for expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,20 @@ Text::Tabs - Perl 6 implementation of `expand` and `unexpand` utilities.
 
 ```
 use Text::Tabs;
-say expand(@lines-with-tabs, 4);
+
 # Text with TAB characters replaced by 4 spaces.
-say unexpand(@lines-without-tabs, 8);
+say expand(@lines-with-tabs, 4);
+say expand("this\tline has \t\t tabs", 4);
+
 # Opposite, but 8 spaces is one TAB character now.
+say unexpand(@lines-without-tabs, 8);
 ```
 
 # DESCRIPTION
 
-It's a simple port of Perl 5 module `Text::Tabs`, which in turn just Perlish implementation of expand/unexpand utilities.
+It's a slightly expanded port of Perl 5 module `Text::Tabs`, which in turn just Perlish implementation of expand/unexpand utilities.
+
+Unlike the Perl5 version, Unexpand does not recognize tab-stops at this time.
 
 # BUGS
 

--- a/lib/Text/Tabs.pm6
+++ b/lib/Text/Tabs.pm6
@@ -2,17 +2,33 @@ use v6;
 
 unit module Text::Tabs;
 
-our sub expand(@input, $tabstop = 8 --> Array) is export {
+multi sub expand(@input, Int $tabstop = 8 --> Array) is export {
     my Array $output = [];
     for @input -> $el {
         my $tmp = '';
-        for (split(/^/, $el, :skip-empty)) {
-            my $l = $_;
-            $l .= subst(/\t/, {" " x $tabstop}, :g);
-            $tmp ~= $l;
+        for $el.split(/^/, :skip-empty) -> Str $line {
+            $tmp ~= expand($line, $tabstop);
         }
         $output.push($tmp);
     }
+    $output;
+}
+
+multi sub expand(Str $input, Int $tabstop = 8 --> Str) is export {
+    my $output = q{};
+    my $position = 0;
+    for $input.split(/\t/, :v) -> $part {
+        if ($part eq "\t") {
+            my $distance-from-stop = $position % $tabstop;
+            my $tab-length = $tabstop - $distance-from-stop;
+            $output ~= q{ } x $tab-length;
+            $position += $tab-length;
+        } else {
+            $position += $part.chars;
+            $output ~= $part;
+        }
+    }
+
     $output;
 }
 

--- a/t/10-sane.t
+++ b/t/10-sane.t
@@ -4,7 +4,7 @@ use Test;
 use lib 'lib';
 use Text::Tabs;
 
-plan 5;
+plan 16;
 
 ok expand(["		"], 4)[0] eq "        ", 'two tabs were converted to 8 spaces';
 ok unexpand(["            "], 4) eq "			", '12 spaces were converted to 3 tabs.';
@@ -12,3 +12,15 @@ ok unexpand([expand(["			"], 4)], 4) eq "			", "unexpand and expand are even";
 
 ok expand([""]) eq [], "empty strings are working";
 ok unexpand([""]) eq [], "empty strings are working";
+
+is expand("no tabs"), 'no tabs', 'No tabs';
+is expand("\t1234567", 4), '    1234567', 'Tab in 1st position';
+is expand("1\t234567", 4), '1   234567', 'Tab in 2nd position';
+is expand("12\t34567", 4), '12  34567', 'Tab in 3rd position';
+is expand("123\t4567", 4), '123 4567', 'Tab in 4th position';
+is expand("1234\t567", 4), '1234    567', 'Tab in 5th position';
+is expand("12345\t67", 4), '12345   67', 'Tab in 6th position';
+is expand("123456\t7", 4), '123456  7', 'Tab in 7th position';
+is expand("1234567\t", 4), '1234567 ', 'Tab in 8th position';
+is expand("f\t\too"), 'f               oo', '2 middle tabs within text';
+is expand("\tfoo\tbar"), '        foo     bar', 'mixed tabs/text';


### PR DESCRIPTION
12\t34 now does the expected thing with tab-stops and better matches the Perl5 version of the module. Bit of kibitzing with types for sanity.

Added a new function for expanding a single line. This can be useful to external modules which previously needed to wrap/unwrap their line as an array.