### PR TITLE
Obey tab-stops for unexpand; call with slurpy @input & named parameter :tab-stop

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -3,12 +3,12 @@
     "name"         : "Text::Tabs",
     "license"      : "Artistic-2.0",
     "tags"         : ["CPAN5"],
-    "version"      : "0.1",
+    "version"      : "0.2.0",
     "description"  : "Perl 6 port of Perl's Text::Tabs",
     "depends"      : [ ],
     "provides"     : {
         "Text::Tabs" : "lib/Text/Tabs.pm6"
     },
-    "author"       : "github:Altai-man",
+    "authors"       : [ "github:Altai-man" ],
     "source-url"   : "git://github.com/Altai-man/perl6-Text-Tabs.git"
 }

--- a/META6.json
+++ b/META6.json
@@ -3,7 +3,7 @@
     "name"         : "Text::Tabs",
     "license"      : "Artistic-2.0",
     "tags"         : ["CPAN5"],
-    "version"      : "0.2.0",
+    "version"      : "0.2.1",
     "description"  : "Perl 6 port of Perl's Text::Tabs",
     "depends"      : [ ],
     "provides"     : {

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Text::Tabs - Perl 6 implementation of `expand` and `unexpand` utilities.
 use Text::Tabs;
 
 # Text with TAB characters replaced by 4 spaces.
-say expand(@lines-with-tabs, 4);
-say expand("this\tline has \t\t tabs", 4);
+say expand(@lines-with-tabs, :tab-stop(4));
+say expand("these\tlines\n\nhave \t\t tabs\n", "in\tthem\ntoo\n", :ts(4));
 
 # Opposite, but 8 spaces is one TAB character now.
-say unexpand(@lines-without-tabs, 8);
+say unexpand(@lines-with-spaces, :tab-stop(8));
 ```
 
 # DESCRIPTION

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ say expand("these\tlines\n\nhave \t\t tabs\n", "in\tthem\ntoo\n", :ts(4));
 
 # Opposite, but 8 spaces is one TAB character now.
 say unexpand(@lines-with-spaces, :tab-stop(8));
+say unexpand("tab >   < here");  # Default tab stop = 8
 ```
 
 # DESCRIPTION
 
 It's a slightly expanded port of Perl 5 module `Text::Tabs`, which in turn just Perlish implementation of expand/unexpand utilities.
-
-Unlike the Perl5 version, Unexpand does not recognize tab-stops at this time.
 
 # BUGS
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,20 @@ Text::Tabs - Perl 6 implementation of `expand` and `unexpand` utilities.
 
 ```
 use Text::Tabs;
-say expand(@lines-with-tabs, 4);
+
 # Text with TAB characters replaced by 4 spaces.
-say unexpand(@lines-without-tabs, 8);
+say expand(@lines-with-tabs, 4);
+say expand("this\tline has \t\t tabs", 4);
+
 # Opposite, but 8 spaces is one TAB character now.
+say unexpand(@lines-without-tabs, 8);
 ```
 
 # DESCRIPTION
 
-It's a simple port of Perl 5 module `Text::Tabs`, which in turn just Perlish implementation of expand/unexpand utilities.
+It's a slightly expanded port of Perl 5 module `Text::Tabs`, which in turn just Perlish implementation of expand/unexpand utilities.
+
+Unlike the Perl5 version, Unexpand does not recognize tab-stops at this time.
 
 # BUGS
 

--- a/lib/Text/Tabs.pm6
+++ b/lib/Text/Tabs.pm6
@@ -1,54 +1,36 @@
 use v6;
 
-unit module Text::Tabs:ver<0.2.0>;
+unit module Text::Tabs:ver<0.2.1>;
 
-sub expand(Int :ts(:$tab-stop) = 8, *@input --> Iterable) is export {
-    my Array $output = [];
-    for @input -> $el {
-        my $tmp = '';
-        for $el.split(/^/, :skip-empty) -> Str $line {
-            $tmp ~= expand-one($line, $tab-stop);
+sub expand(Int :ts(:$tab-stop) = 8, *@input) is export {
+    process-by-lines @input, -> $line {
+        my ($result, @chunks) = $line.split("\t");
+        for @chunks {
+            $result ~= ' ' x $tab-stop - $result.chars % $tab-stop;
+            $result ~= $_;
         }
-        $output.push($tmp);
-    }
-    $output;
+
+        $result;
+    };
 }
 
-sub expand-one(Str $input, Int $tab-stop = 8 --> Str) {
-    my $output = q{};
-    my $position = 0;
-    for $input.split(/\t/, :v) -> $part {
-        if ($part eq "\t") {
-            my $distance-from-stop = $position % $tab-stop;
-            my $tab-length = $tab-stop - $distance-from-stop;
-            $output ~= q{ } x $tab-length;
-            $position += $tab-length;
-        } else {
-            $position += $part.chars;
-            $output ~= $part;
-        }
-    }
-
-    $output;
+sub unexpand(Int :ts(:$tab-stop) = 8, *@input) is export {
+    process-by-lines @input, -> $line {
+        my @e = expand($line, :$tab-stop).comb($tab-stop);
+        # Unless ends on a tab-stop, trailing spaces must not be converted to tab
+        my @last-one = @e.pop if @e and @e[*-1].chars < $tab-stop;
+        s/ ' ' ** 2..* $ /\t/ for @e;
+        (@e, @last-one).flat.join;
+    };
 }
 
-sub unexpand(Int :ts(:$tab-stop) = 8, *@input --> Iterable) is export {
-    my $output;
-    my $ts_as_space = " " x $tab-stop;
-    my @lines;
-
-    for @input -> $el {
-        @lines = split("\n", $el, :skip-empty);
-        @lines = [expand(@lines).flat];
-        my @buff;
-        for @lines -> $line {
-            my $replaced = $line
-            .comb($tab-stop)
-            .map({ $_ eq $ts_as_space ?? "\t" !! $_ })
-            .join('');
-            @buff.push($replaced);
-        }
-        $output.push(join("\n", @buff));
+sub process-by-lines(@input, &process) {
+    @input.map: {
+        # To preserve line endings, use .comb instead of .lines
+        .comb(/:r ^^ \N* \n?/)
+        # Each line gets handled separately
+        .map(&process)
+        # Then joined back together to map back onto a single string
+        .join
     }
-    $output;
 }

--- a/lib/Text/Tabs.pm6
+++ b/lib/Text/Tabs.pm6
@@ -1,26 +1,26 @@
 use v6;
 
-unit module Text::Tabs;
+unit module Text::Tabs:ver<0.2.0>;
 
-multi sub expand(@input, Int $tabstop = 8 --> Array) is export {
+sub expand(Int :ts(:$tab-stop) = 8, *@input --> Iterable) is export {
     my Array $output = [];
     for @input -> $el {
         my $tmp = '';
         for $el.split(/^/, :skip-empty) -> Str $line {
-            $tmp ~= expand($line, $tabstop);
+            $tmp ~= expand-one($line, $tab-stop);
         }
         $output.push($tmp);
     }
     $output;
 }
 
-multi sub expand(Str $input, Int $tabstop = 8 --> Str) is export {
+sub expand-one(Str $input, Int $tab-stop = 8 --> Str) {
     my $output = q{};
     my $position = 0;
     for $input.split(/\t/, :v) -> $part {
         if ($part eq "\t") {
-            my $distance-from-stop = $position % $tabstop;
-            my $tab-length = $tabstop - $distance-from-stop;
+            my $distance-from-stop = $position % $tab-stop;
+            my $tab-length = $tab-stop - $distance-from-stop;
             $output ~= q{ } x $tab-length;
             $position += $tab-length;
         } else {
@@ -32,9 +32,9 @@ multi sub expand(Str $input, Int $tabstop = 8 --> Str) is export {
     $output;
 }
 
-our sub unexpand(@input, $tabstop = 8 --> Array) is export {
+sub unexpand(Int :ts(:$tab-stop) = 8, *@input --> Iterable) is export {
     my $output;
-    my $ts_as_space = " " x $tabstop;
+    my $ts_as_space = " " x $tab-stop;
     my @lines;
 
     for @input -> $el {
@@ -43,7 +43,7 @@ our sub unexpand(@input, $tabstop = 8 --> Array) is export {
         my @buff;
         for @lines -> $line {
             my $replaced = $line
-            .comb($tabstop)
+            .comb($tab-stop)
             .map({ $_ eq $ts_as_space ?? "\t" !! $_ })
             .join('');
             @buff.push($replaced);

--- a/lib/Text/Tabs.pm6
+++ b/lib/Text/Tabs.pm6
@@ -2,17 +2,33 @@ use v6;
 
 unit module Text::Tabs;
 
-our sub expand(@input, $tabstop = 8 --> Array) is export {
+multi sub expand(@input, Int $tabstop = 8 --> Array) is export {
     my Array $output = [];
     for @input -> $el {
         my $tmp = '';
-        for (split(/^/, $el, :skip-empty)) {
-            my $l = $_;
-            $l .= subst(/\t/, {" " x $tabstop}, :g);
-            $tmp ~= $l;
+        for $el.split(/^/, :skip-empty) -> Str $line {
+            $tmp ~= expand($line, $tabstop);
         }
         $output.push($tmp);
     }
+    $output;
+}
+
+multi sub expand(Str $input, Int $tabstop = 8 --> Str) is export {
+    my $output = q{};
+    my $position = 0;
+    for $input.split(/\t/, :v) -> $part {
+        if ($part eq "\t") {
+            my $distance-from-stop = $position % $tabstop;
+            my $tab-length = $tabstop - $distance-from-stop;
+            $output ~= q{ } x $tab-length;
+            $position += $tab-length;
+        } else {
+            $position += $part.chars;
+            $output ~= $part;
+        }
+    }
+
     $output;
 }
 

--- a/t/10-sane.t
+++ b/t/10-sane.t
@@ -4,7 +4,7 @@ use Test;
 use lib 'lib';
 use Text::Tabs;
 
-plan 5;
+plan 16;
 
 ok expand(["		"], 4)[0] eq "        ", 'two tabs were converted to 8 spaces';
 ok unexpand(["            "], 4) eq "			", '12 spaces were converted to 3 tabs.';
@@ -12,3 +12,15 @@ ok unexpand([expand(["			"], 4)], 4) eq "			", "unexpand and expand are even";
 
 ok expand([""]) eq [], "empty strings are working";
 ok unexpand([""]) eq [], "empty strings are working";
+
+is expand("no tabs"), 'no tabs', 'No tabs';
+is expand("\t1234567", 4), '    1234567', 'Tab in 1st position';
+is expand("1\t234567", 4), '1   234567', 'Tab in 2nd position';
+is expand("12\t34567", 4), '12  34567', 'Tab in 3rd position';
+is expand("123\t4567", 4), '123 4567', 'Tab in 4th position';
+is expand("1234\t567", 4), '1234    567', 'Tab in 5th position';
+is expand("12345\t67", 4), '12345   67', 'Tab in 6th position';
+is expand("123456\t7", 4), '123456  7', 'Tab in 7th position';
+is expand("1234567\t", 4), '1234567 ', 'Tab in 8th position';
+is expand("f\t\too"), 'f               oo', '2 middle tabs within text';
+is expand("\tfoo\tbar"), '        foo     bar', 'mixed tabs/text';

--- a/t/10-sane.t
+++ b/t/10-sane.t
@@ -6,21 +6,21 @@ use Text::Tabs;
 
 plan 16;
 
-ok expand(["		"], 4)[0] eq "        ", 'two tabs were converted to 8 spaces';
-ok unexpand(["            "], 4) eq "			", '12 spaces were converted to 3 tabs.';
-ok unexpand([expand(["			"], 4)], 4) eq "			", "unexpand and expand are even";
+is expand("		", :tab-stop(4)), "        ", 'two tabs were converted to 8 spaces';
+is unexpand("            ", :tab-stop(4)), "			", '12 spaces were converted to 3 tabs.';
+is unexpand(expand("			", :ts(4)), :ts(4)), "			", "unexpand and expand are even";
 
-ok expand([""]) eq [], "empty strings are working";
-ok unexpand([""]) eq [], "empty strings are working";
+is expand(""), [], "empty strings are working";
+is unexpand(""), [], "empty strings are working";
 
 is expand("no tabs"), 'no tabs', 'No tabs';
-is expand("\t1234567", 4), '    1234567', 'Tab in 1st position';
-is expand("1\t234567", 4), '1   234567', 'Tab in 2nd position';
-is expand("12\t34567", 4), '12  34567', 'Tab in 3rd position';
-is expand("123\t4567", 4), '123 4567', 'Tab in 4th position';
-is expand("1234\t567", 4), '1234    567', 'Tab in 5th position';
-is expand("12345\t67", 4), '12345   67', 'Tab in 6th position';
-is expand("123456\t7", 4), '123456  7', 'Tab in 7th position';
-is expand("1234567\t", 4), '1234567 ', 'Tab in 8th position';
+is expand("\t1234567", :tab-stop(4)), '    1234567', 'Tab in 1st position';
+is expand("1\t234567", :tab-stop(4)), '1   234567', 'Tab in 2nd position';
+is expand("12\t34567", :tab-stop(4)), '12  34567', 'Tab in 3rd position';
+is expand("123\t4567", :tab-stop(4)), '123 4567', 'Tab in 4th position';
+is expand("1234\t567", :tab-stop(4)), '1234    567', 'Tab in 5th position';
+is expand("12345\t67", :tab-stop(4)), '12345   67', 'Tab in 6th position';
+is expand("123456\t7", :tab-stop(4)), '123456  7', 'Tab in 7th position';
+is expand("1234567\t", :tab-stop(4)), '1234567 ', 'Tab in 8th position';
 is expand("f\t\too"), 'f               oo', '2 middle tabs within text';
 is expand("\tfoo\tbar"), '        foo     bar', 'mixed tabs/text';

--- a/t/10-sane.t
+++ b/t/10-sane.t
@@ -4,7 +4,7 @@ use Test;
 use lib 'lib';
 use Text::Tabs;
 
-plan 16;
+plan 20;
 
 is expand("		", :tab-stop(4)), "        ", 'two tabs were converted to 8 spaces';
 is unexpand("            ", :tab-stop(4)), "			", '12 spaces were converted to 3 tabs.';
@@ -24,3 +24,8 @@ is expand("123456\t7", :tab-stop(4)), '123456  7', 'Tab in 7th position';
 is expand("1234567\t", :tab-stop(4)), '1234567 ', 'Tab in 8th position';
 is expand("f\t\too"), 'f               oo', '2 middle tabs within text';
 is expand("\tfoo\tbar"), '        foo     bar', 'mixed tabs/text';
+
+is unexpand("foo" ~ ' ' x 5 ~ "bar"), "foo\tbar", 'Exactly one tabstop';
+is unexpand("foo" ~ ' ' x 7 ~ "bar"), "foo\t  bar", 'One tabstop and extra';
+is unexpand("foo" ~ ' ' x 13 ~ "bar"), "foo\t\tbar", 'Exactly two tabstops';
+is unexpand("foo" ~ ' ' x 15 ~ "bar"), "foo\t\t  bar", 'Two tabstops and extra';


### PR DESCRIPTION
Building on the tab stop improvements in PR #6 by @rbt, this makes `unexpand()` respect tab stops as well, using the same algorithm as in Perl's `Text::Tabs`.

Also, make the calling interface more flexible by switching to a slurpy `*@input` style, and specifying the tab stop as a named parameter.